### PR TITLE
subscriber forget

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -164,3 +164,20 @@ func (s *SubscriberService) Delete(ctx context.Context, subscriberID string) (*r
 
 	return root, res, nil
 }
+
+func (s *SubscriberService) Forget(ctx context.Context, subscriberID string) (*rootSubscriber, *Response, error) {
+	path := fmt.Sprintf("%s/%s/forget", subscriberEndpoint, subscriberID)
+
+	req, err := s.client.newRequest(http.MethodPost, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(rootSubscriber)
+	res, err := s.client.do(ctx, req, root)
+	if err != nil {
+		return nil, res, err
+	}
+
+	return root, res, nil
+}

--- a/subscribers_test.go
+++ b/subscribers_test.go
@@ -117,3 +117,51 @@ func TestCanCreateSubscrber(t *testing.T) {
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 }
+
+func TestCanDeleteSubscrber(t *testing.T) {
+	client := mailerlite.NewClient(testKey)
+
+	testClient := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.Method, http.MethodDelete)
+		assert.Equal(t, req.URL.String(), "https://connect.mailerlite.com/api/subscribers/1234")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(`OK`)),
+		}
+	})
+
+	ctx := context.TODO()
+
+	client.SetHttpClient(testClient)
+
+	_, res, err := client.Subscriber.Delete(ctx, "1234")
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+}
+
+func TestCanForgetSubscrber(t *testing.T) {
+	client := mailerlite.NewClient(testKey)
+
+	testClient := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.Method, http.MethodPost)
+		assert.Equal(t, req.URL.String(), "https://connect.mailerlite.com/api/subscribers/1234/forget")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(`OK`)),
+		}
+	})
+
+	ctx := context.TODO()
+
+	client.SetHttpClient(testClient)
+
+	_, res, err := client.Subscriber.Forget(ctx, "1234")
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+}


### PR DESCRIPTION
This PR adds support for [forget subscriber](https://developers.mailerlite.com/docs/subscribers.html#forget-a-subscriber) `subscribers/:id/forget`.