### PR TITLE
Remove response body from subscriber delete

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -148,21 +148,20 @@ func (s *SubscriberService) Update(ctx context.Context, subscriber *Subscriber) 
 	return root, res, nil
 }
 
-func (s *SubscriberService) Delete(ctx context.Context, subscriberID string) (*rootSubscriber, *Response, error) {
+func (s *SubscriberService) Delete(ctx context.Context, subscriberID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", subscriberEndpoint, subscriberID)
 
 	req, err := s.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	root := new(rootSubscriber)
-	res, err := s.client.do(ctx, req, root)
+	res, err := s.client.do(ctx, req, nil)
 	if err != nil {
-		return nil, res, err
+		return res, err
 	}
 
-	return root, res, nil
+	return res, nil
 }
 
 func (s *SubscriberService) Forget(ctx context.Context, subscriberID string) (*rootSubscriber, *Response, error) {

--- a/subscribers_test.go
+++ b/subscribers_test.go
@@ -3,11 +3,12 @@ package mailerlite_test
 import (
 	"bytes"
 	"context"
-	"github.com/mailerlite/mailerlite-go"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/mailerlite/mailerlite-go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCanListSubscrbers(t *testing.T) {
@@ -134,9 +135,9 @@ func TestCanDeleteSubscrber(t *testing.T) {
 
 	client.SetHttpClient(testClient)
 
-	_, res, err := client.Subscriber.Delete(ctx, "1234")
+	res, err := client.Subscriber.Delete(ctx, "1234")
 	if err != nil {
-		return
+		assert.Fail(t, "Delete request threw an error")
 	}
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)


### PR DESCRIPTION
**Running `Subscribers.Delete` successfully deleted the entry but threw an error.**

The issue was cause by [Line 203 in `client.go`](https://github.com/mailerlite/mailerlite-go/blob/main/client.go#L203), because we were feeding the `rootSubscriber` into the `Do` function (and thus it not being `nil`).
According to the [MailerLite Docs](https://developers.mailerlite.com/docs/subscribers.html#delete-a-subscriber), the `DELETE` operation shouldn't have a request / response body, so I decided to fix the issue by removing them from the `Delete` function itself.

Additionally, I've fixed the test to catch this behaviour.