### PR TITLE
Differentiate between UPSERT and UPDATE

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -133,8 +133,14 @@ func (s *SubscriberService) Create(ctx context.Context, subscriber *Subscriber) 
 	return root, res, nil
 }
 
+func (s *SubscriberService) Upsert(ctx context.Context, subscriber *Subscriber) (*rootSubscriber, *Response, error) {
+	return s.Create(ctx, subscriber)
+}
+
 func (s *SubscriberService) Update(ctx context.Context, subscriber *Subscriber) (*rootSubscriber, *Response, error) {
-	req, err := s.client.newRequest(http.MethodPost, subscriberEndpoint, subscriber)
+	endpoint := subscriberEndpoint + "/" + subscriber.ID
+
+	req, err := s.client.newRequest(http.MethodPut, endpoint, subscriber)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Currently, the `update` operation implemented is the [Upsert](https://developers.mailerlite.com/docs/subscribers.html#list-all-subscribers), using the `POST` method. However, this method does not allow for editing e-mail addresses, since that it what it matches on.

I have renamed the method to `Upsert` and made it call the `Create` method (since they are exactly the same, but it might be nice for developers to differentiate this in their code).

I have also added the [Update](https://developers.mailerlite.com/docs/subscribers.html#update-a-subscriber) operation, which uses the `PUT` method and matches on ID, thus allowing me to update a subscriber's email.