### PR TITLE
fix missing param for origURL in addOptions()

### DIFF
--- a/client.go
+++ b/client.go
@@ -279,6 +279,13 @@ func addOptions(s string, opt interface{}) (string, error) {
 				origValues.Add(filterKey, split[1])
 			}
 			continue
+		} else {
+			for _, fv := range v {
+				if fv == "" {
+					continue
+				}
+				origValues.Add(k, fv)
+			}
 		}
 	}
 


### PR DESCRIPTION
fix #26

Currently, the request URL remains unchanged even after passing through the addOptions function, even though the values for the Page & Limit attributes in ListSubscriberOptions have been filled in. To address this issue, I have made some adjustments in this pull request.