### PR TITLE
Fix creating subscriber with groups

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -13,7 +13,7 @@ type SubscriberService interface {
 	List(ctx context.Context, options *ListSubscriberOptions) (*RootSubscribers, *Response, error)
 	Count(ctx context.Context) (*Count, *Response, error)
 	Get(ctx context.Context, options *GetSubscriberOptions) (*RootSubscriber, *Response, error)
-	Create(ctx context.Context, subscriber *Subscriber) (*RootSubscriber, *Response, error)
+	Create(ctx context.Context, subscriber *SubscriberToCreate) (*RootSubscriber, *Response, error)
 	Update(ctx context.Context, subscriber *Subscriber) (*RootSubscriber, *Response, error)
 	Delete(ctx context.Context, subscriberID string) (*Response, error)
 	Forget(ctx context.Context, subscriberID string) (*RootSubscriber, *Response, error)
@@ -57,6 +57,18 @@ type Subscriber struct {
 	UpdatedAt      string                 `json:"updated_at,omitempty"`
 	Fields         map[string]interface{} `json:"fields,omitempty"`
 	Groups         []Group                `json:"groups,omitempty"`
+	OptedInAt      string                 `json:"opted_in_at,omitempty"`
+	OptinIP        string                 `json:"optin_ip,omitempty"`
+}
+
+type SubscriberToCreate struct {
+	Email          string                 `json:"email,omitempty"`
+	Status         string                 `json:"status,omitempty"`
+	IPAddress      interface{}            `json:"ip_address,omitempty"`
+	SubscribedAt   string                 `json:"subscribed_at,omitempty"`
+	UnsubscribedAt interface{}            `json:"unsubscribed_at,omitempty"`
+	Fields         map[string]interface{} `json:"fields,omitempty"`
+	Groups         []string               `json:"groups,omitempty"`
 	OptedInAt      string                 `json:"opted_in_at,omitempty"`
 	OptinIP        string                 `json:"optin_ip,omitempty"`
 }
@@ -127,7 +139,7 @@ func (s *subscriberService) Get(ctx context.Context, options *GetSubscriberOptio
 	return root, res, nil
 }
 
-func (s *subscriberService) Create(ctx context.Context, subscriber *Subscriber) (*RootSubscriber, *Response, error) {
+func (s *subscriberService) Create(ctx context.Context, subscriber *SubscriberToCreate) (*RootSubscriber, *Response, error) {
 	req, err := s.client.newRequest(http.MethodPost, subscriberEndpoint, subscriber)
 	if err != nil {
 		return nil, nil, err
@@ -142,7 +154,7 @@ func (s *subscriberService) Create(ctx context.Context, subscriber *Subscriber) 
 	return root, res, nil
 }
 
-func (s *subscriberService) Upsert(ctx context.Context, subscriber *Subscriber) (*RootSubscriber, *Response, error) {
+func (s *subscriberService) Upsert(ctx context.Context, subscriber *SubscriberToCreate) (*RootSubscriber, *Response, error) {
 	return s.Create(ctx, subscriber)
 }
 


### PR DESCRIPTION
According to official docs (https://developers.mailerlite.com/docs/subscribers.html#create-upsert-subscriber), when the subscriber is created, groups should be slices of strings with IDs, not objects.

I also noticed that fields that you can use for sub-creation are limited - I created a separate type that contains only needed fields.